### PR TITLE
refactor: simplify boolean logic in whiskers prop check

### DIFF
--- a/src/ports.rs
+++ b/src/ports.rs
@@ -179,7 +179,7 @@ pub fn query(command: Option<Query>, count: bool, get: Key) -> Result<()> {
 						if prop.property_name == "whiskers" {
 							let matches = prop.value == is.to_string();
 
-							return if if not { !matches } else { matches } {
+							return if not != matches {
 								Some(Value::String(repository.name.to_string()))
 							} else {
 								None


### PR DESCRIPTION
truth table of the condition in question:

| `not` | `matches` | result |
| ----- | --------- | ------ |
| false | false     | false  |
| false | true      | true   |
| true  | false     | true   |
| true  | true      | false  |

this is exclusive-or, so `not != matches` is equivalent.